### PR TITLE
transforming the internal dsl to external

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     testImplementation(kotlin("test"))
+    implementation("com.github.h0tk3y.betterParse:better-parse:0.4.4")
 }
 
 tasks.test {

--- a/src/main/kotlin/Algebra.kt
+++ b/src/main/kotlin/Algebra.kt
@@ -1,0 +1,46 @@
+internal interface ExpAlg<T> {
+    fun lit(n: Int): T
+    operator fun T.plus(value: T): T
+}
+
+internal interface MulAlg<T> : ExpAlg<T> {
+    operator fun T.times(value: T): T
+}
+
+internal fun interface Eval {
+    fun eval(): Int
+}
+
+internal open class EvalExp : ExpAlg<Eval> {
+    override fun lit(n: Int): Eval = Eval { n }
+
+    private fun add(x: Eval, y: Eval): Eval = Eval { x.eval() + y.eval() }
+
+    override fun Eval.plus(value: Eval): Eval = add(this, value)
+}
+
+internal class EvalMul : EvalExp(), MulAlg<Eval> {
+    private fun multiply(a: Eval, b: Eval) = Eval { a.eval() * b.eval() }
+
+    override fun Eval.times(value: Eval): Eval = multiply(this, value)
+}
+
+internal fun interface Print {
+    fun print(): String
+}
+
+internal open class PrintExp : ExpAlg<Print> {
+    override fun lit(n: Int) = Print { "(lit $n)" }
+
+    private fun add(x: Print, y: Print) = Print { "(+ ${x.print()} ${y.print()})" }
+
+    override fun Print.plus(value: Print) = add(this, value)
+}
+
+internal class PrintMul : MulAlg<Print>, PrintExp() {
+    private fun multiply(a: Print, b: Print) = Print {
+        "(* ${a.print()} ${b.print()})"
+    }
+
+    override fun Print.times(value: Print) = multiply(this, value)
+}

--- a/src/main/kotlin/AlgebraParser.kt
+++ b/src/main/kotlin/AlgebraParser.kt
@@ -1,0 +1,55 @@
+import com.github.h0tk3y.betterParse.combinators.*
+import com.github.h0tk3y.betterParse.grammar.parser
+import com.github.h0tk3y.betterParse.lexer.DefaultTokenizer
+import com.github.h0tk3y.betterParse.lexer.literalToken
+import com.github.h0tk3y.betterParse.lexer.regexToken
+import com.github.h0tk3y.betterParse.parser.Parser
+import com.github.h0tk3y.betterParse.parser.toParsedOrThrow
+
+internal inline fun <reified T> MulAlg<T>.createParser(): Pair<DefaultTokenizer, Parser<T>> {
+
+    val int = regexToken("[0-9]+")
+    val plus = literalToken("+")
+    val mult = literalToken("*")
+    val openp = literalToken("(")
+    val closep = literalToken(")")
+    val ws = regexToken("\\s+", ignore = true)
+    val tokenizer = DefaultTokenizer(listOf(int, plus, mult, openp, closep, ws))
+
+    lateinit var termFactory: () -> Parser<T>
+    val multExprFactory = { leftAssociative(parser(termFactory), mult) { a, _, b -> a * b } }
+    val sumExprFactory = { leftAssociative(parser(multExprFactory), plus) { a, _, b -> a + b } }
+    termFactory = {
+        (int use { lit(text.toInt()) }) or (-openp * parser(sumExprFactory) * -closep)
+    }
+
+    return tokenizer to sumExprFactory()
+}
+
+fun main(args: Array<String>) {
+    val exps = listOf(
+        "42" to 42,
+        "3 * 6" to 18,
+        "2 * 3 * 4" to 24,
+        "2 + 3 * 4" to 14,
+        "(2 + 3) * 4" to 20
+    )
+
+    with(EvalMul()) {
+        val (tokenizer, parser) = createParser()
+        exps.forEach { (exp, expected) ->
+            val parseResult = parser.tryParse(tokenizer.tokenize(exp), 0)
+            val evalResult = parseResult.toParsedOrThrow().value.eval()
+            println("$exp evaluates to $evalResult. Expected $expected")
+        }
+    }
+
+    with(PrintMul()) {
+        val (tokenizer, parser) = createParser()
+        exps.forEach { (exp, expected) ->
+            val parseResult = parser.tryParse(tokenizer.tokenize(exp), 0)
+            val evalResult = parseResult.toParsedOrThrow().value.print()
+            println("$exp pretty prints to $evalResult")
+        }
+    }
+}

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -5,9 +5,11 @@ fun main(args: Array<String>) {
     }
     with(EvalMul()) {
         println(e2().eval())
+        println(e3().eval())
     }
     with (PrintMul()) {
         println(e2().print())
+        println(e3().print())
     }
 }
 
@@ -18,49 +20,6 @@ fun <T> e1(): T = lit(1) + lit(2) + lit(3)
 context(MulAlg<T>)
 fun <T> e2(): T = lit(5) + lit(6) * lit(4)
 
-internal interface ExpAlg<T> {
-    fun lit(n: Int): T
-    operator fun T.plus(value: T): T
-}
+context(MulAlg<T>)
+fun <T> e3(): T = (lit(5) + lit(6)) * lit(4)
 
-internal interface MulAlg<T> : ExpAlg<T> {
-    operator fun T.times(value: T): T
-}
-
-internal fun interface Eval {
-    fun eval(): Int
-}
-
-internal open class EvalExp : ExpAlg<Eval> {
-    override fun lit(n: Int): Eval = Eval { n }
-
-    private fun add(x: Eval, y: Eval): Eval = Eval { x.eval() + y.eval() }
-
-    override fun Eval.plus(value: Eval): Eval = add(this, value)
-}
-
-internal class EvalMul : EvalExp(), MulAlg<Eval> {
-    private fun multiply(a: Eval, b: Eval) = Eval { a.eval() * b.eval() }
-
-    override fun Eval.times(value: Eval): Eval = multiply(this, value)
-}
-
-internal fun interface Print {
-    fun print(): String
-}
-
-internal open class PrintExp : ExpAlg<Print> {
-    override fun lit(n: Int) = Print { "(lit $n)" }
-
-    private fun add(x: Print, y: Print) = Print { "(+ ${x.print()} ${y.print()})" }
-
-    override fun Print.plus(value: Print) = add(this, value)
-}
-
-internal class PrintMul : MulAlg<Print>, PrintExp() {
-    private fun multiply(a: Print, b: Print) = Print {
-        "(* ${a.print()} ${b.print()})"
-    }
-
-    override fun Print.times(value: Print) = multiply(this, value)
-}


### PR DESCRIPTION
By adding a parser, we can transform the internal dsl into an external.

The example uses a parser combinator library and combines it with the existing object algebras and interpreters.